### PR TITLE
Added timeout handling

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,7 +1,15 @@
 from pylgtv import WebOsClient
 
-webos_client = WebOsClient('192.168.0.112')
-#webos_client.launch_app('netflix')
+import sys
+import logging
 
-for app in webos_client.get_apps():
-    print(app)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+try:
+    webos_client = WebOsClient('192.168.0.112')
+    #webos_client.launch_app('netflix')
+
+    for app in webos_client.get_apps():
+        print(app)
+except:
+    print("Error connecting to TV")

--- a/pylgtv/webos_client.py
+++ b/pylgtv/webos_client.py
@@ -4,6 +4,9 @@ import codecs
 import json
 import os
 import websockets
+import logging
+
+logger = logging.getLogger(__name__)
 
 from .endpoints import *
 
@@ -28,6 +31,7 @@ class WebOsClient(object):
         self.web_socket = None
         self.command_count = 0
         self.last_response = None
+        self.timeout_connect = 2
 
         self.load_key_file()
 
@@ -49,12 +53,15 @@ class WebOsClient(object):
             key_file_path = self._get_key_file_path()
         key_dict = {}
 
+        logger.debug('load keyfile from %s', key_file_path);
+
         if os.path.isfile(key_file_path):
             with open(key_file_path, 'r') as f:
                 raw_data = f.read()
                 if raw_data:
                     key_dict = json.loads(raw_data)
 
+        logger.debug('getting client_key for %s from %s', self.ip, key_file_path);
         if self.ip in key_dict:
             self.client_key = key_dict[self.ip]
 
@@ -67,6 +74,8 @@ class WebOsClient(object):
             key_file_path = self.key_file_path
         else:
             key_file_path = self._get_key_file_path()
+
+        logger.debug('save keyfile to %s', key_file_path);
 
         with open(key_file_path, 'w+') as f:
             raw_data = f.read()
@@ -109,8 +118,16 @@ class WebOsClient(object):
     @asyncio.coroutine
     def _register(self):
         """Register wrapper."""
-        websocket = yield from  websockets.connect(
-                "ws://{}:{}".format(self.ip, self.port))
+        logger.debug('register on %s', "ws://{}:{}".format(self.ip, self.port));
+        try:
+            websocket = yield from websockets.connect(
+                "ws://{}:{}".format(self.ip, self.port), timeout=self.timeout_connect)
+
+        except:
+            logger.error('register failed to connect to %s', "ws://{}:{}".format(self.ip, self.port));
+            return False
+
+        logger.info('register websocket connected to %s', "ws://{}:{}".format(self.ip, self.port));
 
         try:
             yield from self._send_register_payload(websocket)
@@ -127,8 +144,16 @@ class WebOsClient(object):
     @asyncio.coroutine
     def _command(self, msg):
         """Send a command to the tv."""
-        websocket = yield from websockets.connect(
-                "ws://{}:{}".format(self.ip, self.port))
+        logger.debug('send command to %s', "ws://{}:{}".format(self.ip, self.port));
+        try:
+            websocket = yield from websockets.connect(
+                "ws://{}:{}".format(self.ip, self.port), timeout=self.timeout_connect)
+
+        except:
+            logger.error('command failed to connect to %s', "ws://{}:{}".format(self.ip, self.port));
+            return False
+
+        logger.info('command websocket connected to %s', "ws://{}:{}".format(self.ip, self.port));
 
         try:
             yield from self._send_register_payload(websocket)
@@ -162,7 +187,7 @@ class WebOsClient(object):
         self.last_response = None
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        loop.run_until_complete(self._command(message))
+        loop.run_until_complete(asyncio.wait_for(self._command(message), self.timeout_connect))
 
     def request(self, uri, payload=None):
         """Send a request."""

--- a/pylgtv/webos_client.py
+++ b/pylgtv/webos_client.py
@@ -22,7 +22,7 @@ class PyLGTVPairException(Exception):
 
 
 class WebOsClient(object):
-    def __init__(self, ip, key_file_path=None):
+    def __init__(self, ip, key_file_path=None, timeout_connect=2):
         """Initialize the client."""
         self.ip = ip
         self.port = 3000
@@ -31,7 +31,7 @@ class WebOsClient(object):
         self.web_socket = None
         self.command_count = 0
         self.last_response = None
-        self.timeout_connect = 2
+        self.timeout_connect = timeout_connect
 
         self.load_key_file()
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pylgtv',
-      version='0.1.4',
+      version='0.1.5',
       description='Library to control webOS based LG Tv devices',
       url='https://github.com/TheRealLink/pylgtv',
       author='Dennis Karpienski',


### PR DESCRIPTION
- added logging-
- added timeout handler for connection to TV, to fix error exceptions from OS when TV is off-
- updated the example code to show errors-

Right now the module is making home-assistant crash, and as far as I can see the problem is that the timeout values for the module and home-assistant are off. I reported this bug https://github.com/home-assistant/home-assistant/issues/6749 but there seems to be other related tickets.

I have not done a lot of python, so I don't know if my fix is the right way to do it, but it seems to work :)

