### PR TITLE
change log level to be less spammy

### DIFF
--- a/pylgtv/webos_client.py
+++ b/pylgtv/webos_client.py
@@ -150,7 +150,7 @@ class WebOsClient(object):
             websocket = yield from websockets.connect(
                 "ws://{}:{}".format(self.ip, self.port), timeout=self.timeout_connect)
         except:
-            logger.error('command failed to connect to %s', "ws://{}:{}".format(self.ip, self.port));
+            logger.debug('command failed to connect to %s', "ws://{}:{}".format(self.ip, self.port));
             return False
 
         logger.debug('command websocket connected to %s', "ws://{}:{}".format(self.ip, self.port));

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
       package_data = {'pylgtv': ['handshake.json']},
       install_requires = ['websockets', 'asyncio'],
       zip_safe = True,
-      version = '0.1.6',
+      version = '0.1.7',
       description = 'Library to control webOS based LG Tv devices',
       author = 'Dennis Karpienski',
       author_email = 'dennis@karpienski.de',


### PR DESCRIPTION
Having the connect error be an error log level seems to be too spammy in something like home assistant

https://github.com/home-assistant/home-assistant/issues/7218#issuecomment-297051541

So I changed it to debug